### PR TITLE
Add toggleable toolbar width

### DIFF
--- a/CSL Scrollable Toolbar/CSL Scrollable Toolbar.csproj
+++ b/CSL Scrollable Toolbar/CSL Scrollable Toolbar.csproj
@@ -59,6 +59,8 @@
     <Compile Include="LoadingExtension.cs" />
     <Compile Include="Mod.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UI\Buttons.cs" />
+    <Compile Include="UI\EventHelpers.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/CSL Scrollable Toolbar/LoadingExtension.cs
+++ b/CSL Scrollable Toolbar/LoadingExtension.cs
@@ -36,7 +36,7 @@ namespace ScrollableToolbar
                     break;
             }
 
-            this.EnableToggleToolbarWidth();
+            this.EnableToggleToolbarWidth(mode);
             EventHelpers.StartEvents(mode);
         }
 
@@ -161,14 +161,14 @@ namespace ScrollableToolbar
         /// <summary>
         /// Patches the width of the toolbar to contain more items at once.
         /// </summary>
-        private void EnableToggleToolbarWidth()
+        private void EnableToggleToolbarWidth(LoadMode mode)
         {
             // We only add our switch mode button if the toolbar width hasn't been changed by some other mod, in order to prevent incompatibility
             UITabContainer tsContainer = GameObject.Find("TSContainer").GetComponent<UITabContainer>();
             int currentWidth = Mathf.RoundToInt(tsContainer.width);
             if (currentWidth == 859)
             {
-                Buttons.CreateSwitchModeButton();
+                Buttons.CreateSwitchModeButton(mode);
                 Debug.Log("Created button to switch the toolbar width");
             }
             else

--- a/CSL Scrollable Toolbar/UI/Buttons.cs
+++ b/CSL Scrollable Toolbar/UI/Buttons.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using ColossalFramework.UI;
+using ICities;
 using UnityEngine;
 
 namespace ScrollableToolbar.UI
@@ -12,16 +13,33 @@ namespace ScrollableToolbar.UI
         private static UIMultiStateButton switchModeButton;
         private static float originalTSContainerX;
         private static float originalTSContainerWidth;
-        private static float lastTSContainerX = 590f;
-        private static float lastTSContainerWidth = 859f;
+        private static float lastTSContainerX;
+        private static float lastTSContainerWidth;
         private const float measureRange = 5f;
 
 
         /// <summary>
         /// Creates our button to switch between the different toolbar modes.
         /// </summary>
-        public static void CreateSwitchModeButton()
+        public static void CreateSwitchModeButton(LoadMode mode)
         {
+            // Initialize variables
+            lastTSContainerWidth = 859f;
+            switch (mode)
+            {
+                case LoadMode.NewGame:
+                case LoadMode.LoadGame:
+                case LoadMode.NewAsset:
+                case LoadMode.LoadAsset:
+                default:
+                    lastTSContainerX = 590f;
+                    break;
+                case LoadMode.NewMap:
+                case LoadMode.LoadMap:
+                    lastTSContainerX = 676f;
+                    break;
+            }
+
             // Create button and attach it
             UISlicedSprite tsBar = GameObject.Find("TSBar").GetComponent<UISlicedSprite>();
             switchModeButton = tsBar.AddUIComponent<UIMultiStateButton>();

--- a/CSL Scrollable Toolbar/UI/Buttons.cs
+++ b/CSL Scrollable Toolbar/UI/Buttons.cs
@@ -9,15 +9,18 @@ namespace ScrollableToolbar.UI
 {
     internal static class Buttons
     {
-        internal static UIMultiStateButton switchModeButton;
+        private static UIMultiStateButton switchModeButton;
         private static float originalTSContainerX;
         private static float originalTSContainerWidth;
+        private static float lastTSContainerX = 590f;
+        private static float lastTSContainerWidth = 859f;
+        private const float measureRange = 5f;
 
 
         /// <summary>
         /// Creates our button to switch between the different toolbar modes.
         /// </summary>
-        internal static void CreateSwitchModeButton()
+        public static void CreateSwitchModeButton()
         {
             // Create button and attach it
             UISlicedSprite tsBar = GameObject.Find("TSBar").GetComponent<UISlicedSprite>();
@@ -57,7 +60,7 @@ namespace ScrollableToolbar.UI
             switchModeButton.eventActiveStateIndexChanged += switchModeButton_eventActiveStateIndexChanged;
         }
 
-        public static void switchModeButton_eventActiveStateIndexChanged(UIComponent component, int value)
+        private static void switchModeButton_eventActiveStateIndexChanged(UIComponent component, int value)
         {
             UITabContainer tsContainer = GameObject.Find("TSContainer").GetComponent<UITabContainer>();
             UIButton tsCloseButton = GameObject.Find("TSCloseButton").GetComponent<UIButton>();
@@ -69,6 +72,7 @@ namespace ScrollableToolbar.UI
                     tsContainer.absolutePosition = new Vector2(originalTSContainerX, tsContainer.absolutePosition.y);
                     tsContainer.width = originalTSContainerWidth;
                     break;
+
                 case 1:
                     // Patch to full width
 
@@ -94,12 +98,15 @@ namespace ScrollableToolbar.UI
 
                     break;
             }
+
+            lastTSContainerX = tsContainer.absolutePosition.x;
+            lastTSContainerWidth = tsContainer.width;
         }
 
         /// <summary>
         /// Removes our button to switch between the different toolbar modes.
         /// </summary>
-        internal static void RemoveSwitchModeButton()
+        public static void RemoveSwitchModeButton()
         {
             EventHelpers.ToolbarOpened -= EventHelpers_ToolbarOpened;
             EventHelpers.ToolbarClosed -= EventHelpers_ToolbarClosed;
@@ -120,7 +127,15 @@ namespace ScrollableToolbar.UI
 
         private static void EventHelpers_ToolbarOpened()
         {
-            switchModeButton.isVisible = true;
+            // We need to check if the size and position of TSContainer is still the same as we left it.
+            // If not, then another mod has probably overwritten some stuff and we cannot enable the button.
+            // Sorry Sapphire users, but I assume your skin already patches the width of the toolbar ;)
+            UITabContainer tsContainer = GameObject.Find("TSContainer").GetComponent<UITabContainer>();
+            if (tsContainer.absolutePosition.x >= lastTSContainerX - measureRange && tsContainer.absolutePosition.x <= lastTSContainerX + measureRange &&
+               tsContainer.width >= lastTSContainerWidth - measureRange && tsContainer.width <= lastTSContainerWidth + measureRange)
+            {
+                switchModeButton.isVisible = true;
+            }
         }
 
         private static void EventHelpers_ToolbarClosed()

--- a/CSL Scrollable Toolbar/UI/Buttons.cs
+++ b/CSL Scrollable Toolbar/UI/Buttons.cs
@@ -65,12 +65,15 @@ namespace ScrollableToolbar.UI
             UITabContainer tsContainer = GameObject.Find("TSContainer").GetComponent<UITabContainer>();
             UIButton tsCloseButton = GameObject.Find("TSCloseButton").GetComponent<UIButton>();
 
+            float newX = tsContainer.absolutePosition.x;
+            float newWidth = tsContainer.width;
+
             switch (value)
             {
                 case 0:
                     // Reset to normal width
-                    tsContainer.absolutePosition = new Vector2(originalTSContainerX, tsContainer.absolutePosition.y);
-                    tsContainer.width = originalTSContainerWidth;
+                    newX = originalTSContainerX;
+                    newWidth = originalTSContainerWidth;
                     break;
 
                 case 1:
@@ -79,7 +82,7 @@ namespace ScrollableToolbar.UI
                     // Extend to the right
                     originalTSContainerWidth = tsContainer.width;
                     int extendAmount = (int)((tsCloseButton.absolutePosition.x - tsContainer.absolutePosition.x - tsContainer.width) / 109f);
-                    tsContainer.width += extendAmount * 109f;
+                    newWidth += extendAmount * 109f;
 
                     // Extend to the left
                     originalTSContainerX = tsContainer.absolutePosition.x;
@@ -93,14 +96,16 @@ namespace ScrollableToolbar.UI
                         maxX = Mathf.Max(maxX, advisorButton.absolutePosition.x + advisorButton.width);
                     }
                     extendAmount = (int)((tsContainer.absolutePosition.x - maxX) / 109f);
-                    tsContainer.absolutePosition = new Vector2(tsContainer.absolutePosition.x - extendAmount * 109f, tsContainer.absolutePosition.y);
-                    tsContainer.width += extendAmount * 109f;
+                    newX = tsContainer.absolutePosition.x - extendAmount * 109f;
+                    newWidth += extendAmount * 109f;
 
                     break;
             }
 
-            lastTSContainerX = tsContainer.absolutePosition.x;
-            lastTSContainerWidth = tsContainer.width;
+            lastTSContainerX = newX;
+            lastTSContainerWidth = newWidth;
+            tsContainer.absolutePosition = new Vector2(newX, tsContainer.absolutePosition.y);
+            tsContainer.width = newWidth;
         }
 
         /// <summary>

--- a/CSL Scrollable Toolbar/UI/Buttons.cs
+++ b/CSL Scrollable Toolbar/UI/Buttons.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ColossalFramework.UI;
+using UnityEngine;
+
+namespace ScrollableToolbar.UI
+{
+    internal static class Buttons
+    {
+        internal static UIMultiStateButton switchModeButton;
+        private static float originalTSContainerWidth;
+
+
+        /// <summary>
+        /// Creates our button to switch between the different toolbar modes.
+        /// </summary>
+        internal static void CreateSwitchModeButton()
+        {
+            // Create button and attach it
+            UISlicedSprite tsBar = GameObject.Find("TSBar").GetComponent<UISlicedSprite>();
+            switchModeButton = tsBar.AddUIComponent<UIMultiStateButton>();
+
+            // Set layout
+            switchModeButton.isVisible = false;
+            switchModeButton.size = new Vector2(18, 18);
+            ResetSwitchModeButtonPosition();
+
+            // Set additional settings
+            switchModeButton.playAudioEvents = true;
+            switchModeButton.tooltip = "Toggles the toolbar between normal and full width";
+            switchModeButton.isTooltipLocalized = false;
+
+            // Add background sprites
+            switchModeButton.backgroundSprites.AddState();
+            switchModeButton.backgroundSprites[0].disabled = "OptionBase";
+            switchModeButton.backgroundSprites[0].hovered = "OptionBaseHovered";
+            switchModeButton.backgroundSprites[0].normal = "OptionBase";
+            switchModeButton.backgroundSprites[0].pressed = "OptionBasePressed";
+            switchModeButton.backgroundSprites[1].disabled = "OptionBase";
+            switchModeButton.backgroundSprites[1].normal = "OptionBaseFocused";
+            switchModeButton.backgroundSprites[1].pressed = "OptionBasePressed";
+
+            // Add foreground sprites
+            switchModeButton.foregroundSprites.AddState();
+
+            // Hook onto various events
+            EventHelpers.ToolbarOpened += EventHelpers_ToolbarOpened;
+            EventHelpers.ToolbarClosed += EventHelpers_ToolbarClosed;
+
+            UITabContainer tsContainer = GameObject.Find("TSContainer").GetComponent<UITabContainer>();
+            tsContainer.eventSizeChanged += TSContainer_OnSizeChanged;
+
+            // Listen to various events
+            switchModeButton.eventActiveStateIndexChanged += switchModeButton_eventActiveStateIndexChanged;
+        }
+
+        public static void switchModeButton_eventActiveStateIndexChanged(UIComponent component, int value)
+        {
+            UITabContainer tsContainer = GameObject.Find("TSContainer").GetComponent<UITabContainer>();
+            UIButton tsCloseButton = GameObject.Find("TSCloseButton").GetComponent<UIButton>();
+
+            switch (value)
+            {
+                case 0:
+                    // Reset to normal width
+                    tsContainer.width = originalTSContainerWidth;
+                    break;
+                case 1:
+                    // Patch to full width
+                    originalTSContainerWidth = tsContainer.width;
+                    int extendAmount = (int)((tsCloseButton.absolutePosition.x - tsContainer.absolutePosition.x - tsContainer.width) / 109f);
+                    tsContainer.width += extendAmount * 109f;
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Removes our button to switch between the different toolbar modes.
+        /// </summary>
+        internal static void RemoveSwitchModeButton()
+        {
+            EventHelpers.ToolbarOpened -= EventHelpers_ToolbarOpened;
+            EventHelpers.ToolbarClosed -= EventHelpers_ToolbarClosed;
+
+            UITabContainer tsContainer = GameObject.Find("TSContainer").GetComponent<UITabContainer>();
+            tsContainer.eventSizeChanged -= TSContainer_OnSizeChanged;
+
+            UISlicedSprite tsBar = GameObject.Find("TSBar").GetComponent<UISlicedSprite>();
+            tsBar.RemoveUIComponent(switchModeButton);
+            switchModeButton = null;
+        }
+
+        private static void ResetSwitchModeButtonPosition()
+        {
+            UITabContainer tsContainer = GameObject.Find("TSContainer").GetComponent<UITabContainer>();
+            switchModeButton.absolutePosition = (Vector2)tsContainer.absolutePosition + new Vector2(tsContainer.size.x - switchModeButton.size.x - 8, 8);
+        }
+
+        private static void EventHelpers_ToolbarOpened()
+        {
+            switchModeButton.isVisible = true;
+        }
+
+        private static void EventHelpers_ToolbarClosed()
+        {
+            switchModeButton.isVisible = false;
+        }
+
+        private static void TSContainer_OnSizeChanged(UIComponent component, Vector2 value)
+        {
+            ResetSwitchModeButtonPosition();
+
+            // We have to reset the child components somehow, we hack this by making the current visible panel invisible and visible again.
+            // If you know a better way to reset the layout, let me know!
+            foreach (var child in component.components.Where(c => c.isVisible))
+            {
+                child.isVisible = false;
+                child.isVisible = true;
+            }
+        }
+    }
+}

--- a/CSL Scrollable Toolbar/UI/Buttons.cs
+++ b/CSL Scrollable Toolbar/UI/Buttons.cs
@@ -32,8 +32,9 @@ namespace ScrollableToolbar.UI
             ResetSwitchModeButtonPosition();
 
             // Set additional settings
+            switchModeButton.name = "SwitchToolbarModeButton";
             switchModeButton.playAudioEvents = true;
-            switchModeButton.tooltip = "Toggle the toolbar between normal and full width";
+            switchModeButton.tooltip = "Toggle between normal and extended width";
             switchModeButton.isTooltipLocalized = false;
 
             // Add background sprites

--- a/CSL Scrollable Toolbar/UI/Buttons.cs
+++ b/CSL Scrollable Toolbar/UI/Buttons.cs
@@ -30,7 +30,7 @@ namespace ScrollableToolbar.UI
 
             // Set additional settings
             switchModeButton.playAudioEvents = true;
-            switchModeButton.tooltip = "Toggles the toolbar between normal and full width";
+            switchModeButton.tooltip = "Toggle the toolbar between normal and full width";
             switchModeButton.isTooltipLocalized = false;
 
             // Add background sprites

--- a/CSL Scrollable Toolbar/UI/Buttons.cs
+++ b/CSL Scrollable Toolbar/UI/Buttons.cs
@@ -10,6 +10,7 @@ namespace ScrollableToolbar.UI
     internal static class Buttons
     {
         internal static UIMultiStateButton switchModeButton;
+        private static float originalTSContainerX;
         private static float originalTSContainerWidth;
 
 
@@ -65,13 +66,32 @@ namespace ScrollableToolbar.UI
             {
                 case 0:
                     // Reset to normal width
+                    tsContainer.absolutePosition = new Vector2(originalTSContainerX, tsContainer.absolutePosition.y);
                     tsContainer.width = originalTSContainerWidth;
                     break;
                 case 1:
                     // Patch to full width
+
+                    // Extend to the right
                     originalTSContainerWidth = tsContainer.width;
                     int extendAmount = (int)((tsCloseButton.absolutePosition.x - tsContainer.absolutePosition.x - tsContainer.width) / 109f);
                     tsContainer.width += extendAmount * 109f;
+
+                    // Extend to the left
+                    originalTSContainerX = tsContainer.absolutePosition.x;
+                    GameObject advisorButtonGameObject = GameObject.Find("AdvisorButton");
+                    UIPanel optionsBar = GameObject.Find("OptionsBar").GetComponent<UIPanel>();
+
+                    float maxX = optionsBar.absolutePosition.x + optionsBar.width;
+                    if (advisorButtonGameObject != null)
+                    {
+                        UIMultiStateButton advisorButton = advisorButtonGameObject.GetComponent<UIMultiStateButton>();
+                        maxX = Mathf.Max(maxX, advisorButton.absolutePosition.x + advisorButton.width);
+                    }
+                    extendAmount = (int)((tsContainer.absolutePosition.x - maxX) / 109f);
+                    tsContainer.absolutePosition = new Vector2(tsContainer.absolutePosition.x - extendAmount * 109f, tsContainer.absolutePosition.y);
+                    tsContainer.width += extendAmount * 109f;
+
                     break;
             }
         }

--- a/CSL Scrollable Toolbar/UI/EventHelpers.cs
+++ b/CSL Scrollable Toolbar/UI/EventHelpers.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ColossalFramework.UI;
+using ICities;
+using UnityEngine;
+
+namespace ScrollableToolbar.UI
+{
+    /// <summary>
+    /// This static class contains various UI event helpers.
+    /// </summary>
+    internal static class EventHelpers
+    {
+        /// <summary>
+        /// Start monitoring for various UI events in the game.
+        /// </summary>
+        /// <param name="mode">The game mode.</param>
+        public static void StartEvents(LoadMode mode)
+        {
+            switch (mode)
+            {
+                case LoadMode.NewGame:
+                case LoadMode.LoadGame:
+                default:
+                    HookToolbar();
+                    break;
+                case LoadMode.NewAsset:
+                case LoadMode.LoadAsset:
+                    ToolsModifierControl.toolController.eventEditPrefabChanged += OnAssetEditorModeChange;
+                    break;
+            }
+
+            Debug.Log("Started events");
+        }
+
+        /// <summary>
+        /// Stop monitoring for the UI events in the game.
+        /// </summary>
+        public static void StopEvents()
+        {
+            ToolsModifierControl.toolController.eventEditPrefabChanged -= OnAssetEditorModeChange;
+            UnhookToolbar();
+
+            Debug.Log("Stopped events");
+        }
+
+        /// <summary>
+        /// The asset editor has the ability to change the toolbar on the fly.
+        /// We can monitor for these changes.
+        /// </summary>
+        /// <param name="prefabInfo"></param>
+        private static void OnAssetEditorModeChange(PrefabInfo info)
+        {
+            HookToolbar();
+        }
+
+        public delegate void ToolbarOpenedEventHandler();
+        /// <summary>
+        /// Gets fired when the toolbar has been opened.
+        /// </summary>
+        public static event ToolbarOpenedEventHandler ToolbarOpened;
+
+        public delegate void ToolbarClosedEventHandler();
+        /// <summary>
+        /// Gets fired when the toolbar has been closed.
+        /// </summary>
+        public static event ToolbarClosedEventHandler ToolbarClosed;
+
+        private static bool isToolbarOpen = false;
+
+
+        private static void OnToolbarOpened()
+        {
+            Debug.Log("Toolbar opened");
+            var handler = ToolbarOpened;
+            if (handler != null)
+                handler();
+        }
+
+        private static void OnToolbarClosed()
+        {
+            Debug.Log("Toolbar closed");
+            var handler = ToolbarClosed;
+            if (handler != null)
+                handler();
+        }
+
+        private static void HookToolbar()
+        {
+            UITabContainer tsContainer = GameObject.Find("TSContainer").GetComponent<UITabContainer>();
+            if (tsContainer != null)
+            {
+                foreach (UIScrollablePanel panel in tsContainer.GetComponentsInChildren<UIScrollablePanel>())
+                {
+                    panel.eventVisibilityChanged += TSContainerPanel_OnVisibilityChanged;
+                }
+            }
+        }
+
+        private static void UnhookToolbar()
+        {
+            UITabContainer tsContainer = GameObject.Find("TSContainer").GetComponent<UITabContainer>();
+            if (tsContainer != null)
+            {
+                foreach (UIScrollablePanel panel in tsContainer.GetComponentsInChildren<UIScrollablePanel>())
+                {
+                    panel.eventVisibilityChanged -= TSContainerPanel_OnVisibilityChanged;
+                }
+            }
+        }
+
+        private static void TSContainerPanel_OnVisibilityChanged(UIComponent component, bool value)
+        {
+            // We have to check the visibility of the parent of the parent of the UIScrollablePanel,
+            // since the UIScrollablePanel is bound to a specific tab and we catch this event from every UIScrollablePanel.
+            // This might cause a race condition for invisible tabs that send the event later than visible tabs.
+            if (component.parent.parent.isVisible)
+            {
+                // We have to double check if the panel that has been opened, is actually a toolbar panel.
+                // We can do that by checking how many child components the visible UIScrollablePanel has,
+                // if it has one or more child components, we continue. Otherwise, don't do anything.
+                if (component.childCount > 0)
+                {
+                    if (!isToolbarOpen)
+                    {
+                        OnToolbarOpened();
+                        isToolbarOpen = true;
+                    }
+                }
+            }
+            else if (isToolbarOpen)
+            {
+                OnToolbarClosed();
+                isToolbarOpen = false;
+            }
+        }
+
+    }
+}

--- a/CSL Scrollable Toolbar/UI/EventHelpers.cs
+++ b/CSL Scrollable Toolbar/UI/EventHelpers.cs
@@ -73,7 +73,6 @@ namespace ScrollableToolbar.UI
 
         private static void OnToolbarOpened()
         {
-            Debug.Log("Toolbar opened");
             var handler = ToolbarOpened;
             if (handler != null)
                 handler();
@@ -81,7 +80,6 @@ namespace ScrollableToolbar.UI
 
         private static void OnToolbarClosed()
         {
-            Debug.Log("Toolbar closed");
             var handler = ToolbarClosed;
             if (handler != null)
                 handler();

--- a/CSL Scrollable Toolbar/UI/EventHelpers.cs
+++ b/CSL Scrollable Toolbar/UI/EventHelpers.cs
@@ -53,6 +53,7 @@ namespace ScrollableToolbar.UI
         /// <param name="prefabInfo"></param>
         private static void OnAssetEditorModeChange(PrefabInfo info)
         {
+            OnToolbarClosed();
             HookToolbar();
         }
 

--- a/CSL Scrollable Toolbar/UI/EventHelpers.cs
+++ b/CSL Scrollable Toolbar/UI/EventHelpers.cs
@@ -13,12 +13,19 @@ namespace ScrollableToolbar.UI
     /// </summary>
     internal static class EventHelpers
     {
+        private static void Initialize()
+        {
+            isToolbarOpen = false;
+        }
+
         /// <summary>
         /// Start monitoring for various UI events in the game.
         /// </summary>
         /// <param name="mode">The game mode.</param>
         public static void StartEvents(LoadMode mode)
         {
+            Initialize();
+
             switch (mode)
             {
                 case LoadMode.NewGame:
@@ -69,7 +76,7 @@ namespace ScrollableToolbar.UI
         /// </summary>
         public static event ToolbarClosedEventHandler ToolbarClosed;
 
-        private static bool isToolbarOpen = false;
+        private static bool isToolbarOpen;
 
 
         private static void OnToolbarOpened()


### PR DESCRIPTION
With this feature, players can toggle the toolbar width between normal and extended through a button that appears top right in the toolbar.
