### PR TITLE
Add custom configuration and state

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,19 @@
+# Configurations
+
+Scrollable Toolbar supports various configurations. They are saved in
+`ScrollableToolbar.xml` in the
+local mod folder. On Windows, this is
+`%LOCALAPPDATA%\Colossal Order\Cities_Skylines\Addons\Mods\ScrollableToolbar`.
+
+## Features
+*Italic values* are the default values. The following settings can be found in
+the `Features` tree:
+
+ Feature                   | Key name                   | Supported values
+ ------------------------- | -------------------------- | ----------------
+ Scrolling on toolbar      | ToolbarScrolling           | *true*, false
+ Switch toolbar width mode | ToolbarToggleExtendedWidth | *true*, false
+
+## State
+These settings are found in the `State` tree. Please do not change any of these,
+unless you know what you're doing. I'm not responsible if you broke your game.

--- a/CSL Scrollable Toolbar/CSL Scrollable Toolbar.csproj
+++ b/CSL Scrollable Toolbar/CSL Scrollable Toolbar.csproj
@@ -52,6 +52,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration.cs" />
     <Compile Include="Debug.cs" />
     <Compile Include="Detour\CustomMouseHandler.cs" />
     <Compile Include="Detour\RedirectionHelper.cs" />
@@ -63,6 +64,8 @@
     <Compile Include="Mod.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UI\Buttons.cs" />
+    <Compile Include="Utils\FileUtils.cs" />
+    <Compile Include="Utils\PluginUtils.cs" />
     <Compile Include="Utils\ReflectionUtils.cs" />
     <Compile Include="Utils\ToolbarUtils.cs" />
   </ItemGroup>

--- a/CSL Scrollable Toolbar/Configuration.cs
+++ b/CSL Scrollable Toolbar/Configuration.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Serialization;
+using ScrollableToolbar.Utils;
+
+namespace ScrollableToolbar
+{
+    [XmlRoot("Configuration")]
+    public class Configuration
+    {
+        [XmlRoot("Features")]
+        public class FeaturesConfig
+        {
+            public FeaturesConfig()
+            {
+                this.ToolbarScrolling = true;
+                this.ToolbarToggleExtendedWidth = true;
+            }
+
+            public bool ToolbarScrolling { get; set; }
+
+            public bool ToolbarToggleExtendedWidth { get; set; }
+        }
+
+        [XmlRoot("State")]
+        public class StateConfig
+        {
+            public StateConfig()
+            {
+                this.ToolbarHasExtendedWidth = false;
+            }
+
+            public bool ToolbarHasExtendedWidth { get; set; }
+        }
+
+        public Configuration()
+        {
+            this.Features = new FeaturesConfig();
+            this.State = new StateConfig();
+        }
+
+        public FeaturesConfig Features { get; set; }
+
+        public StateConfig State { get; set; }
+
+        [XmlIgnore]
+        public static Configuration Instance { get; private set; }
+
+
+        /// <summary>
+        /// Load configuration.
+        /// </summary>
+        public static void Load()
+        {
+            string path = Path.Combine(FileUtils.GetDataFolder(), Mod.AssemblyName + ".xml");
+            if (File.Exists(path))
+            {
+                using (StreamReader sr = new StreamReader(path))
+                {
+                    Instance = (Configuration)new XmlSerializer(typeof(Configuration)).Deserialize(sr);
+                }
+                Debug.Log("Loaded configuration");
+            }
+            else
+            {
+                Instance = new Configuration();
+                Debug.Log("No configuration file found, loaded default");
+            }
+        }
+
+        /// <summary>
+        /// Save configuration.
+        /// </summary>
+        public static void Save()
+        {
+            if (Instance == null)
+            {
+                Debug.Warning("Cannot save configuration when there's no configuration instance!");
+                return;
+            }
+
+            string path = Path.Combine(FileUtils.GetDataFolder(), Mod.AssemblyName + ".xml");
+            if (!Directory.Exists(Path.GetDirectoryName(path)))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path));
+            }
+            using (StreamWriter sw = new StreamWriter(path))
+            {
+                new XmlSerializer(typeof(Configuration)).Serialize(sw, Instance);
+            }
+            Debug.Log("Saved configuration");
+        }
+    }
+}

--- a/CSL Scrollable Toolbar/LoadingExtension.cs
+++ b/CSL Scrollable Toolbar/LoadingExtension.cs
@@ -24,27 +24,39 @@ namespace ScrollableToolbar
             base.OnLevelLoaded(mode);
 
             Configuration.Load();
+            bool isActive = false;
 
-            switch (mode)
+            if (Configuration.Instance.Features.ToolbarScrolling)
             {
-                case LoadMode.NewGame:
-                case LoadMode.LoadGame:
-                default:
-                    this.PatchPanels();
-                    this.PatchAdditionalComponents();
-                    break;
-                case LoadMode.NewAsset:
-                case LoadMode.LoadAsset:
-                    // The asset editor has the ability to change the toolbar on the fly,
-                    // so we have to repatch our toolbar panels if this happens.
-                    AssetEditorEvents.AssetEditorModeChanged += AssetEditorEvents_AssetEditorModeChanged;
-                    this.PatchAdditionalComponents();
-                    break;
+                switch (mode)
+                {
+                    case LoadMode.NewGame:
+                    case LoadMode.LoadGame:
+                    default:
+                        this.PatchPanels();
+                        this.PatchAdditionalComponents();
+                        break;
+                    case LoadMode.NewAsset:
+                    case LoadMode.LoadAsset:
+                        // The asset editor has the ability to change the toolbar on the fly,
+                        // so we have to repatch our toolbar panels if this happens.
+                        AssetEditorEvents.AssetEditorModeChanged += AssetEditorEvents_AssetEditorModeChanged;
+                        this.PatchAdditionalComponents();
+                        break;
+                }
+                isActive = true;
             }
 
-            this.EnableToggleToolbarWidth(mode);
+            if (Configuration.Instance.Features.ToolbarToggleExtendedWidth)
+            {
+                this.EnableToggleToolbarWidth(mode);
+                isActive = true;
+            }
 
-            EventsController.StartEvents(mode);
+            if (isActive)
+            {
+                EventsController.StartEvents(mode);
+            }
         }
 
         /// <summary>
@@ -54,9 +66,12 @@ namespace ScrollableToolbar
         {
             base.OnLevelUnloading();
 
-            AssetEditorEvents.AssetEditorModeChanged -= this.AssetEditorEvents_AssetEditorModeChanged;
-            this.UnpatchPanels();
-            this.UnpatchAdditionalComponents();
+            if (Configuration.Instance.Features.ToolbarScrolling)
+            {
+                AssetEditorEvents.AssetEditorModeChanged -= this.AssetEditorEvents_AssetEditorModeChanged;
+                this.UnpatchPanels();
+                this.UnpatchAdditionalComponents();
+            }
 
             this.DisableToggleToolbarWidth();
 

--- a/CSL Scrollable Toolbar/LoadingExtension.cs
+++ b/CSL Scrollable Toolbar/LoadingExtension.cs
@@ -23,6 +23,8 @@ namespace ScrollableToolbar
         {
             base.OnLevelLoaded(mode);
 
+            Configuration.Load();
+
             switch (mode)
             {
                 case LoadMode.NewGame:
@@ -59,6 +61,8 @@ namespace ScrollableToolbar
             this.DisableToggleToolbarWidth();
 
             EventsController.StopEvents();
+
+            Configuration.Save();
         }
 
         private bool[] originalStates;

--- a/CSL Scrollable Toolbar/Mod.cs
+++ b/CSL Scrollable Toolbar/Mod.cs
@@ -8,9 +8,13 @@ namespace ScrollableToolbar
 {
     public class Mod : IUserMod
     {
+        internal const string FriendlyName = "Scrollable Toolbar";
+        internal const string AssemblyName = "ScrollableToolbar";
+        internal const ulong WorkshopId = 451700838;
+
         public string Name
         {
-            get { return "Scrollable Toolbar"; }
+            get { return FriendlyName; }
         }
 
         public string Description

--- a/CSL Scrollable Toolbar/UI/Buttons.cs
+++ b/CSL Scrollable Toolbar/UI/Buttons.cs
@@ -80,6 +80,9 @@ namespace ScrollableToolbar.UI
 
             // Listen to various events
             switchModeButton.eventActiveStateIndexChanged += switchModeButton_eventActiveStateIndexChanged;
+
+            // Depending on the previous state, set correct mode
+            switchModeButton.activeStateIndex = Configuration.Instance.State.ToolbarHasExtendedWidth ? 1 : 0;
         }
 
         /// <summary>
@@ -144,6 +147,9 @@ namespace ScrollableToolbar.UI
             lastTSContainerWidth = newWidth;
             tsContainer.absolutePosition = new Vector2(newX, tsContainer.absolutePosition.y);
             tsContainer.width = newWidth;
+
+            // Save state
+            Configuration.Instance.State.ToolbarHasExtendedWidth = value == 1;
         }
 
         private static void ResetSwitchModeButtonPosition()

--- a/CSL Scrollable Toolbar/Utils/FileUtils.cs
+++ b/CSL Scrollable Toolbar/Utils/FileUtils.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using ColossalFramework.IO;
+using ColossalFramework.Plugins;
+
+namespace ScrollableToolbar.Utils
+{
+    internal static class FileUtils
+    {
+        public static string GetModFolder()
+        {
+            var pluginInfo = PluginUtils.GetPluginInfo();
+            return pluginInfo != null ? pluginInfo.modPath : null;
+        }
+
+        public static string GetDataFolder()
+        {
+            return Path.Combine(DataLocation.modsPath, Mod.AssemblyName);
+        }
+    }
+}

--- a/CSL Scrollable Toolbar/Utils/PluginUtils.cs
+++ b/CSL Scrollable Toolbar/Utils/PluginUtils.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using ColossalFramework.Plugins;
+
+namespace ScrollableToolbar.Utils
+{
+    internal static class PluginUtils
+    {
+        public static PluginManager.PluginInfo GetPluginInfo()
+        {
+            return PluginManager.instance.GetPluginsInfo().FirstOrDefault(p => p.name == Mod.AssemblyName || p.publishedFileID.AsUInt64 == Mod.WorkshopId);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ mod too.
     completely if another mod changes the toolbar. Please consult the notes
     below.
 
+## Custom configuration settings
+For more information about customizing your configuration settings, go to
+[CONFIGURATION.md](CONFIGURATION.md).
+
 ## Installation
 Go to the
 [Steam Workshop](http://steamcommunity.com/sharedfiles/filedetails/?id=451700838)


### PR DESCRIPTION
With this players can customize the settings by editing `ScrollableToolbar.xml`. Currently, the two features that are included, can be turned on and off individually.

For the rest we have the ability to save our current state between game sessions. This is currently only used to save the current mode of the toolbar width.

This can be extended when needed.
